### PR TITLE
Provide a sequence of files or folders with tests.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -36,15 +36,17 @@ if (fs.existsSync(argsConfigPath)) {
 };
 _.assign(argsConfig, argv);
 
-/* Set up tests folder */
+/* Set up test folders */
 
-if (argsConfig.target) {
-    var testsDir = path.resolve(cwd, argsConfig.target);
-} else if (argsConfig._ && argsConfig._[0]) {
-    var testsDir = path.resolve(cwd, argsConfig._[0]);
+if (argsConfig._ && argsConfig._.length) {
+    var targets = argsConfig._;
+} else if (argsConfig.targets && argsConfig.targets.length) {
+    var targets = argsConfig.targets;
 } else {
-    var testsDir = path.resolve(cwd, "tests");
+    var targets = ["tests"];
 };
+
+var testDirs = targets.map(target => path.resolve(cwd, target))
 
 /* Set up reports folder */
 
@@ -65,7 +67,7 @@ mkdirp.sync(reportsDir);
  * @property {TestCase[]} [testCases=[]] - List of all executed test cases. It
  *  populates when a test launches. It is used to store full information about
  *  executed tests and may be used in reporter.
- * @property {string} testsDir - Path to tests directory or single test module.
+ * @property {string} testDirs - Path to test directories or test modules.
  *  If it contains path to directory, tests will be loaded recursive from it.
  *  By default `GlaceJS` tries to load tests from `tests` folder in current
  *  work directory.
@@ -105,7 +107,7 @@ mkdirp.sync(reportsDir);
 var config = module.exports = {
     curTestCase: null,
     testCases: [],
-    testsDir: testsDir,
+    testDirs: testDirs,
     reportsDir: reportsDir,
     log: {
         file: path.resolve(cwd, "glacejs.log"),

--- a/lib/globals.js
+++ b/lib/globals.js
@@ -121,14 +121,16 @@ global.session = (name, ctx, func) => {
     sessNum++;
     ctx.sessionNumber = sessNum;
 
-    if (!fs.existsSync(CONF.testsDir)) {
-        throw new ConfigError(
-            `File or folder with tests "${CONF.testsDir}" is absent`);
-    };
+    for (var testDir of CONF.testDirs) {
+        if (!fs.existsSync(testDir)) {
+            throw new ConfigError(
+                `File or folder with tests "${testDir}" is absent`);
+        };
 
-    var rootConftest = path.resolve(path.dirname(CONF.testsDir),
-                                    "conftest.js");
-    if (fs.existsSync(rootConftest)) require(rootConftest);
+        var rootConftest = path.resolve(path.dirname(testDir),
+                                        "conftest.js");
+        if (fs.existsSync(rootConftest)) require(rootConftest);
+    };
 
     scope(name, () => {
         beforeSession(ctx);

--- a/lib/help.js
+++ b/lib/help.js
@@ -17,7 +17,7 @@ var d = function () {
 };
 
 var argv = require("yargs")
-    .usage("\nglace [options] [tests-file-or-folder]".white.bold)
+    .usage("\nglace [options] [test-files-or-folders]".white.bold)
     .options({
         /* configuration */
         "args-config": {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -3,11 +3,11 @@
  * Makes tests root session.
  *
  * - runner loads root `conftest.js` if it is located on one level with
- *   `CONF.testsDir`;
- * - if `CONF.testsDir` is file with tests, runner loads and executes it;
- * - if `CONF.testsDir` is folder runner loads files inside recursive if
+ *   each of `CONF.testDirs`;
+ * - if each of `CONF.testDirs` is file with tests, runner loads and executes it;
+ * - if each of `CONF.testDirs` is folder runner loads files inside recursive if
  *   file name starts with `test` and ends with `.js`;
- * - inside each subfolder of `CONF.testsDir` runner loads `conftest.js`
+ * - inside each subfolder of each of `CONF.testDirs` runner loads `conftest.js`
  *   file if it is present;
  *
  * @module
@@ -20,24 +20,27 @@ require("./globals");
 
 session(() => {
 
-    if (!fs.statSync(CONF.testsDir).isDirectory()) {
-        require(CONF.testsDir);
-        return;
-    };
+    for (var testDir of CONF.testDirs) {
 
-    var loadTests = testsDir => {
-        for (var fileName of fs.readdirSync(testsDir)) {
-            var filePath = path.resolve(testsDir, fileName);
+        if (!fs.statSync(testDir).isDirectory()) {
+            require(testDir);
+            continue;
+        };
 
-            if (fileName === "conftest.js") require(filePath);
+        var loadTests = dir => {
+            for (var fileName of fs.readdirSync(dir)) {
+                var filePath = path.resolve(dir, fileName);
 
-            if (fileName.startsWith("test") && fileName.endsWith(".js")) {
-                require(filePath);
-            };
-            if (fs.lstatSync(filePath).isDirectory()) {
-                loadTests(filePath);
+                if (fileName === "conftest.js") require(filePath);
+
+                if (fileName.startsWith("test") && fileName.endsWith(".js")) {
+                    require(filePath);
+                };
+                if (fs.lstatSync(filePath).isDirectory()) {
+                    loadTests(filePath);
+                };
             };
         };
+        loadTests(testDir);
     };
-    loadTests(CONF.testsDir);
 });

--- a/tutorials/console-args.md
+++ b/tutorials/console-args.md
@@ -1,6 +1,6 @@
 `GlaceJS` supports follow command line arguments:
 
-- `<path>` (**optional**) - File or folder path, where tests are located. For example, `glace myTests.js` or `glace path/to/tests-folder`. In folder it loads files with tests recursively. If file with tests is not specified directly, it loads files with prefix `test` and extension `.js` only. If argument is not specified, it looks inside folder `tests` in current work directory.
+- `<paths>` (**optional**) - Sequence of file or folder paths, where tests are located. For example, `glace myTests.js` or `glace path/to/tests-folder`. In folder it loads files with tests recursively. If file with tests is not specified directly, it loads files with prefix `test` and extension `.js` only. If argument is not specified, it looks inside folder `tests` in current work directory.
 - `--web` (**optional**) - Activates steps for web testing in browser via selenium. If option is specified, selenium server and browser will launched automatically on session begin and will be stopped at session end.
 - `--dont-install-drivers` (**optional**) - Don't install selenium webdrivers on session start.
 - `--platform <type>` (**optional**) - Platfrom type. Supported values are `pc`, `android`, `ios`. Default value is `pc`. For example, `--platform android`.


### PR DESCRIPTION
#3 
Problem: Currently it's possible to specify only one root folder
or file with tests. It's not useful when it needs to pass a sequence
of folders or files.
Solution: Provide mechanism to load a sequence of folders or files.